### PR TITLE
Add analytics: profile views, block clicks, date-range overview and trend chart

### DIFF
--- a/drizzle/0001_add_total_views.sql
+++ b/drizzle/0001_add_total_views.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "user" ADD COLUMN IF NOT EXISTS "total_views" integer DEFAULT 0 NOT NULL;

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -60,6 +60,7 @@ export const user = pgTable('user', {
   // Analytics fields
   totalRevenue: integer('total_revenue').notNull().default(0), // in cents
   totalSalesCount: integer('total_sales_count').notNull().default(0),
+  totalViews: integer('total_views').notNull().default(0),
   createdAt: timestamp('created_at').defaultNow().notNull(),
   updatedAt: timestamp('updated_at')
     .defaultNow()

--- a/src/routes/$username/admin/analytics/index.tsx
+++ b/src/routes/$username/admin/analytics/index.tsx
@@ -1,10 +1,14 @@
-import { createFileRoute } from '@tanstack/react-router'
+import { useMemo, useState } from 'react'
 import { useQuery } from '@tanstack/react-query'
+import { createFileRoute } from '@tanstack/react-router'
+import { Package } from 'lucide-react'
+
 import {
   AppHeader,
   AppHeaderContent,
   AppHeaderDescription,
 } from '@/components/app-header'
+import { Badge } from '@/components/ui/badge'
 import {
   Card,
   CardContent,
@@ -12,7 +16,8 @@ import {
   CardHeader,
   CardTitle,
 } from '@/components/ui/card'
-import { Badge } from '@/components/ui/badge'
+import { Input } from '@/components/ui/input'
+import { Spinner } from '@/components/ui/spinner'
 import {
   Table,
   TableBody,
@@ -21,11 +26,9 @@ import {
   TableHeader,
   TableRow,
 } from '@/components/ui/table'
-import { authClient } from '@/lib/auth-client'
 import { trpcClient } from '@/integrations/tanstack-query/root-provider'
-import { formatPrice, cn } from '@/lib/utils'
-import { Package } from 'lucide-react'
-import { Spinner } from '@/components/ui/spinner'
+import { authClient } from '@/lib/auth-client'
+import { cn, formatPrice } from '@/lib/utils'
 
 export const Route = createFileRoute('/$username/admin/analytics/')({
   component: AnalyticsPage,
@@ -34,196 +37,176 @@ export const Route = createFileRoute('/$username/admin/analytics/')({
 function AnalyticsPage() {
   const { data: session } = authClient.useSession()
 
-  const { data: profileAnalytics, isLoading: isLoadingProfile } = useQuery({
-    queryKey: ['analytics', 'profile', session?.user?.id],
+  const today = new Date().toISOString().slice(0, 10)
+  const thirtyDaysAgo = new Date(Date.now() - 29 * 24 * 60 * 60 * 1000)
+    .toISOString()
+    .slice(0, 10)
+
+  const [from, setFrom] = useState(thirtyDaysAgo)
+  const [to, setTo] = useState(today)
+
+  const { data: overview, isLoading: isLoadingOverview } = useQuery({
+    queryKey: ['analytics', 'overview', session.user.id, from, to],
     queryFn: async () => {
-      if (!session?.user?.id) return null
-      return await trpcClient.analytics.getProfileAnalytics.query({
+      if (!session.user.id) return null
+      return await trpcClient.analytics.getOverview.query({
         userId: session.user.id,
+        from,
+        to,
       })
     },
-    enabled: !!session?.user?.id,
+    enabled: !!session.user.id,
   })
 
   const { data: productAnalytics, isLoading: isLoadingProducts } = useQuery({
-    queryKey: ['analytics', 'products', session?.user?.id],
+    queryKey: ['analytics', 'products', session.user.id],
     queryFn: async () => {
-      if (!session?.user?.id) return []
+      if (!session.user.id) return []
       return await trpcClient.analytics.getProductAnalytics.query({
         userId: session.user.id,
       })
     },
-    enabled: !!session?.user?.id,
+    enabled: !!session.user.id,
   })
 
-  const isLoading = isLoadingProfile || isLoadingProducts
+  const isLoading = isLoadingOverview || isLoadingProducts
 
-  // Show loading spinner while session or initial data loads
-  if (!session?.user?.id || isLoading) {
+  if (!session.user.id || isLoading) {
     return (
       <div className="flex items-center justify-center min-h-[60vh]">
-        <div className="flex flex-col items-center gap-3">
-          <Spinner />
-        </div>
+        <Spinner />
       </div>
     )
   }
 
-  // Calculate some derived stats
   const totalProducts = productAnalytics?.length ?? 0
   const activeProducts = productAnalytics?.filter((p) => p.isActive).length ?? 0
   const avgOrderValue =
-    profileAnalytics?.totalSalesCount && profileAnalytics.totalSalesCount > 0
+    overview?.totals.totalSalesCount && overview.totals.totalSalesCount > 0
       ? Math.round(
-          profileAnalytics.totalRevenue / profileAnalytics.totalSalesCount,
+          overview.totals.totalRevenue / overview.totals.totalSalesCount,
         )
       : 0
 
   return (
     <div className="space-y-6">
-      {/* Page Header */}
       <AppHeader>
         <AppHeaderContent title="Analytics">
           <AppHeaderDescription>
-            Track your sales performance and product metrics
+            Track sales, views, and clicks performance
           </AppHeaderDescription>
         </AppHeaderContent>
       </AppHeader>
 
-      {/* Stats Grid */}
-      <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-4">
-        {/* Total Revenue Card */}
-        <Card className="relative overflow-hidden border-0 shadow-sm ring-1 ring-slate-200">
-          <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-            <CardTitle className="text-sm font-medium text-slate-600">
-              Total Revenue
-            </CardTitle>
-          </CardHeader>
-          <CardContent>
-            <div className="text-2xl font-bold text-slate-900">
-              {formatPrice(profileAnalytics?.totalRevenue ?? 0)}
-            </div>
-            <p className="text-xs text-slate-500 mt-1">Lifetime earnings</p>
-          </CardContent>
-        </Card>
-
-        {/* Total Sales Card */}
-        <Card className="relative overflow-hidden border-0 shadow-sm ring-1 ring-slate-200">
-          <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-            <CardTitle className="text-sm font-medium text-slate-600">
-              Total Sales
-            </CardTitle>
-          </CardHeader>
-          <CardContent>
-            <div className="text-2xl font-bold text-slate-900">
-              {profileAnalytics?.totalSalesCount ?? 0}
-            </div>
-            <p className="text-xs text-slate-500 mt-1">Successful checkouts</p>
-          </CardContent>
-        </Card>
-
-        {/* Average Order Value Card */}
-        <Card className="relative overflow-hidden border-0 shadow-sm ring-1 ring-slate-200">
-          <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-            <CardTitle className="text-sm font-medium text-slate-600">
-              Avg Order Value
-            </CardTitle>
-          </CardHeader>
-          <CardContent>
-            <div className="text-2xl font-bold text-slate-900">
-              {formatPrice(avgOrderValue)}
-            </div>
-            <p className="text-xs text-slate-500 mt-1">Per transaction</p>
-          </CardContent>
-        </Card>
-
-        {/* Products Card */}
-        <Card className="relative overflow-hidden border-0 shadow-sm ring-1 ring-slate-200">
-          <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-            <CardTitle className="text-sm font-medium text-slate-600">
-              Products
-            </CardTitle>
-          </CardHeader>
-          <CardContent>
-            <div className="text-2xl font-bold text-slate-900">
-              {totalProducts}
-            </div>
-            <p className="text-xs text-slate-500 mt-1">
-              {activeProducts} active
-            </p>
-          </CardContent>
-        </Card>
-      </div>
-
-      {/* Product Performance Table */}
       <Card className="border-0 shadow-sm ring-1 ring-slate-200">
         <CardHeader className="pb-3 border-b border-slate-100">
-          <div className="flex items-center gap-2">
-            <div>
-              <CardTitle className="text-base font-semibold">
-                Product Performance
-              </CardTitle>
-              <CardDescription className="text-xs">
-                Revenue and sales breakdown by product
-              </CardDescription>
-            </div>
+          <CardTitle className="text-base">Date Range Filter</CardTitle>
+          <CardDescription className="text-xs">
+            Filter chart and period totals by date
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="pt-4 grid gap-3 md:grid-cols-2">
+          <div className="space-y-1">
+            <p className="text-xs text-slate-500">From</p>
+            <Input type="date" value={from} onChange={(e) => setFrom(e.target.value)} />
           </div>
+          <div className="space-y-1">
+            <p className="text-xs text-slate-500">To</p>
+            <Input type="date" value={to} onChange={(e) => setTo(e.target.value)} />
+          </div>
+        </CardContent>
+      </Card>
+
+      <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-4">
+        <StatCard title="Total Revenue" value={formatPrice(overview?.totals.totalRevenue ?? 0)} sub="Lifetime earnings" />
+        <StatCard title="Total Sales" value={overview?.totals.totalSalesCount ?? 0} sub="Successful checkouts" />
+        <StatCard title="Total Views" value={overview?.totals.totalViews ?? 0} sub="Profile page views" />
+        <StatCard title="Total Clicks" value={overview?.totals.totalClicks ?? 0} sub="All block clicks" />
+      </div>
+
+      <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-4">
+        <StatCard title="Clicks / Block" value={(overview?.totals.clicksPerBlock ?? 0).toFixed(2)} sub={`${overview?.totals.totalBlocks ?? 0} blocks`} />
+        <StatCard title="Avg Order Value" value={formatPrice(avgOrderValue)} sub="Per transaction" />
+        <StatCard title="Range Revenue" value={formatPrice(overview?.range.revenue ?? 0)} sub="For selected dates" />
+        <StatCard title="Range Sales" value={overview?.range.sales ?? 0} sub="For selected dates" />
+      </div>
+
+      <Card className="border-0 shadow-sm ring-1 ring-slate-200">
+        <CardHeader className="pb-3 border-b border-slate-100">
+          <CardTitle className="text-base font-semibold">Sales & Revenue Trend</CardTitle>
+          <CardDescription className="text-xs">
+            Shadcn-style chart card for selected date range
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="pt-6">
+          <SimpleBarChart data={overview?.chart ?? []} />
+        </CardContent>
+      </Card>
+
+      <Card className="border-0 shadow-sm ring-1 ring-slate-200">
+        <CardHeader className="pb-3 border-b border-slate-100">
+          <CardTitle className="text-base font-semibold">Block Click Performance</CardTitle>
+          <CardDescription className="text-xs">
+            Total clicks by block
+          </CardDescription>
         </CardHeader>
         <CardContent className="p-0">
           <Table>
             <TableHeader className="bg-slate-50">
               <TableRow className="border-slate-100 hover:bg-slate-50">
-                <TableHead className="text-xs font-semibold text-slate-500 uppercase h-10">
-                  Product
-                </TableHead>
-                <TableHead className="text-xs font-semibold text-slate-500 uppercase h-10 text-right">
-                  Sales
-                </TableHead>
-                <TableHead className="text-xs font-semibold text-slate-500 uppercase h-10 text-right">
-                  Revenue
-                </TableHead>
-                <TableHead className="text-xs font-semibold text-slate-500 uppercase h-10 text-right">
-                  Status
-                </TableHead>
+                <TableHead className="text-xs font-semibold text-slate-500 uppercase h-10">Block</TableHead>
+                <TableHead className="text-xs font-semibold text-slate-500 uppercase h-10 text-right">Type</TableHead>
+                <TableHead className="text-xs font-semibold text-slate-500 uppercase h-10 text-right">Clicks</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {(overview?.blocks ?? []).map((block) => (
+                <TableRow key={block.id} className="group border-slate-100 hover:bg-slate-50/50">
+                  <TableCell className="py-3">
+                    <p className="font-medium text-slate-900 truncate max-w-[240px]">{block.title}</p>
+                  </TableCell>
+                  <TableCell className="py-3 text-right text-slate-600">{block.type}</TableCell>
+                  <TableCell className="py-3 text-right font-semibold text-slate-900">{block.clicks}</TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        </CardContent>
+      </Card>
+
+      <Card className="border-0 shadow-sm ring-1 ring-slate-200">
+        <CardHeader className="pb-3 border-b border-slate-100">
+          <CardTitle className="text-base font-semibold">Product Performance</CardTitle>
+          <CardDescription className="text-xs">Revenue and sales breakdown by product</CardDescription>
+        </CardHeader>
+        <CardContent className="p-0">
+          <Table>
+            <TableHeader className="bg-slate-50">
+              <TableRow className="border-slate-100 hover:bg-slate-50">
+                <TableHead className="text-xs font-semibold text-slate-500 uppercase h-10">Product</TableHead>
+                <TableHead className="text-xs font-semibold text-slate-500 uppercase h-10 text-right">Sales</TableHead>
+                <TableHead className="text-xs font-semibold text-slate-500 uppercase h-10 text-right">Revenue</TableHead>
+                <TableHead className="text-xs font-semibold text-slate-500 uppercase h-10 text-right">Status</TableHead>
               </TableRow>
             </TableHeader>
             <TableBody>
               {productAnalytics && productAnalytics.length > 0 ? (
                 productAnalytics.map((product) => (
-                  <TableRow
-                    key={product.id}
-                    className="group border-slate-100 hover:bg-slate-50/50"
-                  >
+                  <TableRow key={product.id} className="group border-slate-100 hover:bg-slate-50/50">
                     <TableCell className="py-3">
                       <div className="flex items-center gap-3">
                         <div className="h-10 w-10 rounded-lg bg-slate-100 flex items-center justify-center overflow-hidden flex-shrink-0">
                           {product.image ? (
-                            <img
-                              src={product.image}
-                              alt={product.title}
-                              className="h-full w-full object-cover"
-                            />
+                            <img src={product.image} alt={product.title} className="h-full w-full object-cover" />
                           ) : (
                             <Package className="h-5 w-5 text-slate-400" />
                           )}
                         </div>
-                        <div className="min-w-0">
-                          <p className="font-medium text-slate-900 truncate max-w-[200px]">
-                            {product.title}
-                          </p>
-                        </div>
+                        <p className="font-medium text-slate-900 truncate max-w-[200px]">{product.title}</p>
                       </div>
                     </TableCell>
-                    <TableCell className="py-3 text-right">
-                      <span className="font-medium text-slate-700">
-                        {product.salesCount}
-                      </span>
-                    </TableCell>
-                    <TableCell className="py-3 text-right">
-                      <span className="font-semibold text-slate-900">
-                        {formatPrice(product.totalRevenue)}
-                      </span>
-                    </TableCell>
+                    <TableCell className="py-3 text-right font-medium text-slate-700">{product.salesCount}</TableCell>
+                    <TableCell className="py-3 text-right font-semibold text-slate-900">{formatPrice(product.totalRevenue)}</TableCell>
                     <TableCell className="py-3 text-right">
                       <Badge
                         variant="outline"
@@ -241,16 +224,11 @@ function AnalyticsPage() {
                 ))
               ) : (
                 <TableRow>
-                  <TableCell
-                    colSpan={4}
-                    className="h-32 text-center text-slate-500"
-                  >
+                  <TableCell colSpan={4} className="h-32 text-center text-slate-500">
                     <div className="flex flex-col items-center gap-2">
                       <Package className="h-8 w-8 text-slate-300" />
                       <p>No products yet</p>
-                      <p className="text-xs text-slate-400">
-                        Create a product to start tracking analytics
-                      </p>
+                      <p className="text-xs text-slate-400">Create a product to start tracking analytics</p>
                     </div>
                   </TableCell>
                 </TableRow>
@@ -259,6 +237,52 @@ function AnalyticsPage() {
           </Table>
         </CardContent>
       </Card>
+
+      <p className="text-xs text-slate-500">{activeProducts} of {totalProducts} products are active.</p>
+    </div>
+  )
+}
+
+function StatCard({ title, value, sub }: { title: string; value: string | number; sub: string }) {
+  return (
+    <Card className="relative overflow-hidden border-0 shadow-sm ring-1 ring-slate-200">
+      <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+        <CardTitle className="text-sm font-medium text-slate-600">{title}</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <div className="text-2xl font-bold text-slate-900">{value}</div>
+        <p className="text-xs text-slate-500 mt-1">{sub}</p>
+      </CardContent>
+    </Card>
+  )
+}
+
+function SimpleBarChart({ data }: { data: Array<{ date: string; sales: number; revenue: number }> }) {
+  const maxRevenue = useMemo(
+    () => data.reduce((max, item) => Math.max(max, item.revenue), 0),
+    [data],
+  )
+
+  if (data.length === 0) {
+    return <p className="text-sm text-slate-500">No order data for this date range.</p>
+  }
+
+  return (
+    <div className="space-y-3">
+      {data.map((item) => (
+        <div key={item.date} className="space-y-1">
+          <div className="flex items-center justify-between text-xs text-slate-500">
+            <span>{item.date}</span>
+            <span>{item.sales} sales</span>
+          </div>
+          <div className="h-2 rounded bg-slate-100 overflow-hidden">
+            <div
+              className="h-full bg-slate-900"
+              style={{ width: `${maxRevenue > 0 ? (item.revenue / maxRevenue) * 100 : 0}%` }}
+            />
+          </div>
+        </div>
+      ))}
     </div>
   )
 }


### PR DESCRIPTION
### Motivation
- Provide total views and clicks metrics for creators and surface per-block click counts in the analytics UI.  
- Allow filtering analytics by date range and show a simple trend visualization for sales/revenue.  
- Record profile views and block clicks on the public profile so analytics reflect real usage.

### Description
- Add `totalViews` to the `user` schema and include a migration SQL file at `drizzle/0001_add_total_views.sql` to persist the column.  
- Add TRPC mutations `user.trackProfileView` and `block.trackClick` that increment `user.totalViews` and `blocks.clicks` respectively, and add a new `analytics.getOverview` query that returns lifetime totals, range totals, daily chart data and block rows (supports `from`/`to` date filters).  
- Update the public profile UI to call the new analytics mutations: a profile view is sent on mount and a block click is sent before opening external block URLs.  
- Replace and extend the admin analytics page at `src/routes/$username/admin/analytics/index.tsx` to include date-range inputs, `Total Views` and `Total Clicks` cards, `Clicks / Block`, a block click performance table, and a simple bar-style trend chart implemented with existing UI primitives as a fallback to the requested shadcn chart.

### Testing
- Ran `npx eslint src/routes/$username/index.tsx` and `npx eslint src/routes/$username/admin/analytics/index.tsx`, which completed successfully for those files.  
- Ran `npx eslint src/integrations/trpc/router.ts`, which reported pre-existing lint errors in the router file (these are unrelated to the new logic).  
- Attempted to add the shadcn chart with `npx shadcn@latest add chart`, but the environment refused registry access (`403`), so a UI-primitives fallback chart was implemented instead.  
- Attempted to run the app with `npm run dev`, but the environment failed due to a missing optional Rollup native package (`@rollup/rollup-linux-x64-gnu`), preventing a local dev server run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6989e6f0a1348333bbe85aaab766a47f)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Profile view and block click tracking now capture user engagement metrics automatically
  * Date range filtering enables refined analytics queries and more targeted performance insights
  * Expanded analytics dashboard displays new Total Views and Total Clicks metrics
  * Redesigned analytics interface features StatCards and enhanced charting components for improved data visualization

* **Bug Fixes**
  * Enhanced navigation handling in authentication callback for improved stability

<!-- end of auto-generated comment: release notes by coderabbit.ai -->