### PR TITLE
Refactor: remove refund support from commerce flows

### DIFF
--- a/src/lib/invoice.ts
+++ b/src/lib/invoice.ts
@@ -73,21 +73,6 @@ export async function generateInvoicePdf(
     align: 'right',
   })
 
-  // Refund info if applicable
-  if (order.refundedAmount && order.refundedAmount > 0) {
-    doc.setTextColor(220, 50, 50)
-    doc.text(
-      `Refunded: -${formatPrice(order.refundedAmount)}`,
-      pageWidth - 14,
-      finalY + 7,
-      { align: 'right' },
-    )
-    doc.setTextColor(0, 0, 0)
-    const netAmount = order.amountPaid - order.refundedAmount
-    doc.text(`Net: ${formatPrice(netAmount)}`, pageWidth - 14, finalY + 14, {
-      align: 'right',
-    })
-  }
 
   // Footer
   doc.setFontSize(10)

--- a/src/routes/$username/admin/balance/index.tsx
+++ b/src/routes/$username/admin/balance/index.tsx
@@ -173,13 +173,6 @@ function BalancePage() {
           description="All time (net of fees)"
           isLoading={isLoading}
         />
-        <BalanceCard
-          title="Total Refunds"
-          value={summary?.totalRefunds ?? 0}
-          description="All time"
-          isLoading={isLoading}
-          negative
-        />
       </div>
 
       {/* Payout Action */}
@@ -190,10 +183,6 @@ function BalancePage() {
             <p className="text-sm text-muted-foreground">
               Available = funds ready to withdraw. Pending = funds still in hold
               ({summary?.holdPeriodDays ?? 7} days).
-            </p>
-            <p className="text-xs text-amber-600 mt-2">
-              Refunds after a payout can make your available balance negative
-              until new sales settle.
             </p>
             {hasPendingPayout && (
               <p className="text-xs text-muted-foreground mt-1">
@@ -471,10 +460,6 @@ function getTransactionTypeConfig(type: string) {
   switch (type) {
     case 'sale':
       return { label: 'Sale', color: 'emerald' }
-    case 'refund':
-      return { label: 'Refund', color: 'red' }
-    case 'partial_refund':
-      return { label: 'Refund (Legacy)', color: 'amber' }
     case 'payout':
       return { label: 'Payout', color: 'blue' }
     case 'fee':

--- a/src/routes/d/$token.tsx
+++ b/src/routes/d/$token.tsx
@@ -223,14 +223,6 @@ function OrderDeliveryPage() {
                   {formatPrice(order.amountPaid)}
                 </span>
               </div>
-              {order.refundedAmount > 0 && (
-                <div className="flex justify-between text-sm">
-                  <span className="text-red-500">Refunded</span>
-                  <span className="font-semibold text-red-500">
-                    -{formatPrice(order.refundedAmount)}
-                  </span>
-                </div>
-              )}
             </div>
           </CardContent>
         </Card>


### PR DESCRIPTION
### Motivation
- The codebase needs to stop supporting refunds and remove refund-specific state, APIs, UI, and analytics paths so the system operates without refund behavior.
- Refund-related fields and transaction types (`refundedAmount`, `refundedAt`, `refundReason`, `ORDER_STATUS.REFUNDED`, `TRANSACTION_TYPE.REFUND`, etc.) must be removed to avoid dead/conditional code and simplify financial calculations.
- Analytics and reconciliation should report full sales revenue (sale-only ledger semantics) and ignore refunds going forward.

### Description
- Removed refund status and transaction types and dropped order refund columns from the active schema, eliminating `ORDER_STATUS.REFUNDED`, `ORDER_STATUS.PARTIALLY_REFUNDED`, `TRANSACTION_TYPE.REFUND`, and order refund fields from runtime schema (`src/db/schema.ts`).
- Deleted the `order.refund` and `order.partialRefund` tRPC mutations and removed refund-aware transaction filtering and updates in the backend, changing analytics/balance/product revenue queries to use sale-only transactions in `src/integrations/trpc/router.ts`.
- Updated admin UI to remove refund controls, badges, and messaging and to stop rendering refunded amounts on orders and balance pages in `src/routes/$username/admin/orders/index.tsx` and `src/routes/$username/admin/balance/index.tsx`.
- Removed refund display from buyer-facing delivery and invoice artifacts so invoices and the delivery page show full paid amounts only in `src/lib/invoice.ts` and `src/routes/d/$token.tsx`.
- Rewrote the financial reconciliation script to compare cached revenue against sale-only ledger aggregates and removed refund-specific drift checks in `scripts/reconcile-financial-ledger.ts`.
- Files modified and why: `src/db/schema.ts` (remove refund enums/fields and comments), `src/integrations/trpc/router.ts` (remove refund APIs and use sale-only filters for analytics/balance/product revenue), `src/routes/$username/admin/orders/index.tsx` (remove refund UI/mutations, badges, texts), `src/routes/$username/admin/balance/index.tsx` (remove refund card and txn labels), `src/lib/invoice.ts` (remove refunded/net lines), `src/routes/d/$token.tsx` (remove refunded line in order summary), and `scripts/reconcile-financial-ledger.ts` (adjust reconciliation to sale-only semantics).

### Testing
- Ran repo-wide searches (`rg`) to verify refund-related tokens were removed from the modified `src/` and `scripts/` paths and found no remaining matches in those targets (succeeded).
- Attempted to run the test suite with `npm test` but it failed because project dev dependencies are not installed in this environment (`vitest: not found`).
- Attempted `npm install` and `npm run build` but both were blocked by network/registry restrictions in the environment (registry `403 Forbidden` and missing CLI binaries), so full automated test/build validation could not be completed.
- Committed the refactor locally; code builds/CI should be run in your normal environment to confirm typing and runtime behavior.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698b73a394a4833390dbcf12fd964da5)