### PR TITLE
Refactor admin loading UX to section-scoped spinners

### DIFF
--- a/src/components/ui/data-table.tsx
+++ b/src/components/ui/data-table.tsx
@@ -43,6 +43,7 @@ import {
   SelectValue,
 } from '@/components/ui/select'
 import { cn } from '@/lib/utils'
+import { Spinner } from '@/components/ui/spinner'
 
 interface DataTableProps<TData, TValue> {
   columns: ColumnDef<TData, TValue>[]
@@ -50,6 +51,9 @@ interface DataTableProps<TData, TValue> {
   filterPlaceholder?: string
   filterColumn?: string
   searchKey?: string
+  isLoading?: boolean
+  loadingText?: string
+  emptyText?: string
 }
 
 export function DataTable<TData, TValue>({
@@ -57,6 +61,9 @@ export function DataTable<TData, TValue>({
   data,
   filterPlaceholder = 'Filter...',
   searchKey,
+  isLoading = false,
+  loadingText = 'Loading...',
+  emptyText = 'No results.',
 }: DataTableProps<TData, TValue>) {
   const [rowSelection, setRowSelection] = React.useState({})
   const [columnVisibility, setColumnVisibility] =
@@ -153,7 +160,14 @@ export function DataTable<TData, TValue>({
                   colSpan={columns.length}
                   className="h-24 text-center"
                 >
-                  No results.
+                  {isLoading ? (
+                    <div className="flex items-center justify-center gap-2 text-muted-foreground">
+                      <Spinner className="h-4 w-4" />
+                      <span>{loadingText}</span>
+                    </div>
+                  ) : (
+                    emptyText
+                  )}
                 </TableCell>
               </TableRow>
             )}

--- a/src/routes/$username/admin/analytics/index.tsx
+++ b/src/routes/$username/admin/analytics/index.tsx
@@ -36,10 +36,10 @@ import {
   PopoverContent,
   PopoverTrigger,
 } from '@/components/ui/popover'
-import { Skeleton } from '@/components/ui/skeleton'
 import { trpcClient } from '@/integrations/tanstack-query/root-provider'
 import { authClient } from '@/lib/auth-client'
 import { cn, formatPrice } from '@/lib/utils'
+import { Spinner } from '@/components/ui/spinner'
 
 export const Route = createFileRoute('/$username/admin/analytics/')({
   component: AnalyticsPage,
@@ -196,9 +196,8 @@ function StatCard({
       </CardHeader>
       <CardContent>
         {isLoading ? (
-          <div className="space-y-2">
-            <Skeleton className="h-6 w-24" />
-            <Skeleton className="h-4 w-16" />
+          <div className="flex items-center justify-center py-4">
+            <Spinner className="h-5 w-5 text-muted-foreground" />
           </div>
         ) : (
           <>
@@ -232,12 +231,8 @@ function EngagementCard({
       </CardHeader>
       <CardContent>
         {isLoading ? (
-          <div className="space-y-4">
-            <div className="flex gap-8">
-              <Skeleton className="h-12 w-20" />
-              <Skeleton className="h-12 w-20" />
-            </div>
-            <Skeleton className="h-[200px] w-full" />
+          <div className="h-[300px] flex items-center justify-center">
+            <Spinner className="h-5 w-5 text-muted-foreground" />
           </div>
         ) : (
           <div className="space-y-4">
@@ -362,16 +357,8 @@ function TopBlocksCard({
       </CardHeader>
       <CardContent>
         {isLoading ? (
-          <div className="space-y-3">
-            {[...Array(3)].map((_, i) => (
-              <div key={i} className="flex items-center gap-3">
-                <Skeleton className="h-8 w-8 rounded" />
-                <div className="flex-1 space-y-1">
-                  <Skeleton className="h-4 w-32" />
-                  <Skeleton className="h-2 w-full" />
-                </div>
-              </div>
-            ))}
+          <div className="flex items-center justify-center py-8">
+            <Spinner className="h-5 w-5 text-muted-foreground" />
           </div>
         ) : blocks.length === 0 ? (
           <p className="text-sm text-muted-foreground text-center py-4">
@@ -436,16 +423,8 @@ function TopProductsCard({
       </CardHeader>
       <CardContent>
         {isLoading ? (
-          <div className="space-y-3">
-            {[...Array(3)].map((_, i) => (
-              <div key={i} className="flex items-center gap-3">
-                <Skeleton className="h-10 w-10 rounded" />
-                <div className="flex-1 space-y-1">
-                  <Skeleton className="h-4 w-32" />
-                  <Skeleton className="h-3 w-20" />
-                </div>
-              </div>
-            ))}
+          <div className="flex items-center justify-center py-8">
+            <Spinner className="h-5 w-5 text-muted-foreground" />
           </div>
         ) : products.length === 0 ? (
           <p className="text-sm text-muted-foreground text-center py-4">
@@ -521,8 +500,8 @@ function RevenueChart({
         <CardHeader>
           <CardTitle>Net Revenue Trend</CardTitle>
         </CardHeader>
-        <CardContent className="h-[300px] flex flex-col gap-4">
-          <Skeleton className="h-full w-full rounded-lg" />
+        <CardContent className="h-[300px] flex items-center justify-center">
+          <Spinner className="h-5 w-5 text-muted-foreground" />
         </CardContent>
       </Card>
     )

--- a/src/routes/$username/admin/balance/index.tsx
+++ b/src/routes/$username/admin/balance/index.tsx
@@ -16,11 +16,11 @@ import {
 import { Button } from '@/components/ui/button'
 import { Badge } from '@/components/ui/badge'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
-import { Skeleton } from '@/components/ui/skeleton'
 import { authClient } from '@/lib/auth-client'
 import { trpcClient } from '@/integrations/tanstack-query/root-provider'
 import { formatPrice } from '@/lib/utils'
 import { toastManager } from '@/components/ui/toast'
+import { Spinner } from '@/components/ui/spinner'
 
 function getFinanceUiError(message: string): string {
   const lower = message.toLowerCase()
@@ -72,7 +72,7 @@ function BalancePage() {
   })
 
   // Payouts list
-  const { data: payoutsList } = useQuery({
+  const { data: payoutsList, isLoading: isPayoutsLoading } = useQuery({
     queryKey: ['balance', 'payouts', session?.user?.id],
     queryFn: async () => {
       if (!session?.user?.id) return []
@@ -134,6 +134,8 @@ function BalancePage() {
   })
 
   const isLoading = isSummaryLoading
+  const isTransactionsSectionLoading = isTxnsLoading
+  const isPayoutsSectionLoading = isPayoutsLoading
   const availableBalance = summary?.availableBalance ?? 0
   const hasPendingPayout = (payoutsList ?? []).some(
     (p: any) => p.status === 'pending',
@@ -212,14 +214,19 @@ function BalancePage() {
       </Card>
 
       {/* Payouts Section */}
-      {(payoutsList ?? []).length > 0 && (
+      {(isPayoutsSectionLoading || (payoutsList ?? []).length > 0) && (
         <Card>
           <CardHeader>
             <CardTitle>Payout History</CardTitle>
           </CardHeader>
           <CardContent>
-            <div className="space-y-3">
-              {(payoutsList ?? []).map((payout: any) => (
+            {isPayoutsSectionLoading ? (
+              <div className="flex items-center justify-center py-8">
+                <Spinner className="h-5 w-5 text-muted-foreground" />
+              </div>
+            ) : (
+              <div className="space-y-3">
+                {(payoutsList ?? []).map((payout: any) => (
                 <div
                   key={payout.id}
                   className="flex items-center justify-between p-4 rounded-lg border bg-card"
@@ -256,8 +263,9 @@ function BalancePage() {
                     )}
                   </div>
                 </div>
-              ))}
-            </div>
+                ))}
+              </div>
+            )}
           </CardContent>
         </Card>
       )}
@@ -268,18 +276,9 @@ function BalancePage() {
           <CardTitle>Transaction History</CardTitle>
         </CardHeader>
         <CardContent>
-          {isTxnsLoading ? (
-            <div className="space-y-3">
-              {[...Array(5)].map((_, i) => (
-                <div key={i} className="flex items-center gap-3">
-                  <Skeleton className="h-10 w-10 rounded-lg" />
-                  <div className="flex-1 space-y-1">
-                    <Skeleton className="h-4 w-32" />
-                    <Skeleton className="h-3 w-48" />
-                  </div>
-                  <Skeleton className="h-4 w-16" />
-                </div>
-              ))}
+          {isTransactionsSectionLoading ? (
+            <div className="flex items-center justify-center py-8">
+              <Spinner className="h-5 w-5 text-muted-foreground" />
             </div>
           ) : (txns ?? []).length === 0 ? (
             <div className="text-center py-12">
@@ -323,9 +322,8 @@ function BalanceCard({
       </CardHeader>
       <CardContent>
         {isLoading ? (
-          <div className="space-y-2">
-            <Skeleton className="h-7 w-28" />
-            <Skeleton className="h-4 w-20" />
+          <div className="flex items-center justify-center py-4">
+            <Spinner className="h-5 w-5 text-muted-foreground" />
           </div>
         ) : (
           <>

--- a/src/routes/$username/admin/index.tsx
+++ b/src/routes/$username/admin/index.tsx
@@ -26,13 +26,13 @@ import {
   PopoverContent,
   PopoverTrigger,
 } from '@/components/ui/popover'
-import { Skeleton } from '@/components/ui/skeleton'
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar'
 import { trpcClient } from '@/integrations/tanstack-query/root-provider'
 import { authClient } from '@/lib/auth-client'
 import { ShareProfileModal } from '@/components/share-profile-modal'
 import { BASE_URL } from '@/lib/constans'
 import { cn, formatPrice } from '@/lib/utils'
+import { Spinner } from '@/components/ui/spinner'
 
 export const Route = createFileRoute('/$username/admin/')({
   component: HomePage,
@@ -174,7 +174,7 @@ function HomePage() {
             <div className="flex items-baseline gap-2">
               <span className="text-4xl font-mono tracking-tight">
                 {isLoadingBalance ? (
-                  <Skeleton className="h-8 w-24" />
+                  <Spinner className="h-5 w-5 text-muted-foreground" />
                 ) : (
                   formatPrice(balance?.currentBalance ?? 0)
                 )}
@@ -259,12 +259,8 @@ function EngagementCard({
       </CardHeader>
       <CardContent>
         {isLoading ? (
-          <div className="space-y-4">
-            <div className="flex gap-8">
-              <Skeleton className="h-12 w-20" />
-              <Skeleton className="h-12 w-20" />
-            </div>
-            <Skeleton className="h-50 w-full" />
+          <div className="h-[300px] flex items-center justify-center">
+            <Spinner className="h-5 w-5 text-muted-foreground" />
           </div>
         ) : (
           <div className="space-y-4">
@@ -392,16 +388,8 @@ function TopBlocksCard({
       </CardHeader>
       <CardContent>
         {isLoading ? (
-          <div className="space-y-3">
-            {[...Array(3)].map((_, i) => (
-              <div key={i} className="flex items-center gap-3">
-                <Skeleton className="h-8 w-8 rounded" />
-                <div className="flex-1 space-y-1">
-                  <Skeleton className="h-4 w-32" />
-                  <Skeleton className="h-2 w-full" />
-                </div>
-              </div>
-            ))}
+          <div className="flex items-center justify-center py-8">
+            <Spinner className="h-5 w-5 text-muted-foreground" />
           </div>
         ) : blocks.length === 0 ? (
           <p className="text-sm text-muted-foreground text-center py-4">
@@ -469,16 +457,8 @@ function TopProductsCard({
       </CardHeader>
       <CardContent>
         {isLoading ? (
-          <div className="space-y-3">
-            {[...Array(3)].map((_, i) => (
-              <div key={i} className="flex items-center gap-3">
-                <Skeleton className="h-10 w-10 rounded" />
-                <div className="flex-1 space-y-1">
-                  <Skeleton className="h-4 w-32" />
-                  <Skeleton className="h-3 w-20" />
-                </div>
-              </div>
-            ))}
+          <div className="flex items-center justify-center py-8">
+            <Spinner className="h-5 w-5 text-muted-foreground" />
           </div>
         ) : products.length === 0 ? (
           <p className="text-sm text-muted-foreground text-center py-4">

--- a/src/routes/$username/admin/orders/index.tsx
+++ b/src/routes/$username/admin/orders/index.tsx
@@ -61,7 +61,7 @@ function getStatusBadge(status: string) {
 
 function OrdersPage() {
   const { data: session } = authClient.useSession()
-  const { data: orders, refetch } = useQuery({
+  const { data: orders, refetch, isLoading: isOrdersLoading, isFetching: isOrdersFetching } = useQuery({
     queryKey: ['orders', session?.user?.id],
     queryFn: async () => {
       if (!session?.user?.id) return []
@@ -269,6 +269,8 @@ function OrdersPage() {
         data={orders || []}
         searchKey="buyerEmail"
         filterPlaceholder="Filter by email..."
+        isLoading={(isOrdersLoading || isOrdersFetching) && (orders?.length ?? 0) === 0}
+        loadingText="Loading orders..."
       />
     </div>
   )

--- a/src/routes/$username/admin/products/index.tsx
+++ b/src/routes/$username/admin/products/index.tsx
@@ -42,6 +42,7 @@ import {
 } from '@/components/app-header'
 import { DataTable } from '@/components/ui/data-table'
 import { DataTableColumnHeader } from '@/components/ui/data-table'
+import { Spinner } from '@/components/ui/spinner'
 
 export const Route = createFileRoute('/$username/admin/products/')({
   component: ProductAdminRoute,
@@ -371,7 +372,7 @@ function ProductAdminRoute() {
 
   const { data: session } = authClient.useSession()
 
-  const { data: products = [] } = useQuery({
+  const { data: products = [], isLoading: isProductsLoading, isFetching: isProductsFetching } = useQuery({
     queryKey: ['products', session?.user?.id],
     queryFn: async () => {
       if (!session?.user?.id) return []
@@ -410,7 +411,11 @@ function ProductAdminRoute() {
         </AppHeaderActions>
       </AppHeader>
 
-      {products.length === 0 ? (
+      {(isProductsLoading || isProductsFetching) && products.length === 0 ? (
+        <div className="flex items-center justify-center py-12">
+          <Spinner className="h-5 w-5 text-muted-foreground" />
+        </div>
+      ) : products.length === 0 ? (
         <EmptyProduct />
       ) : (
         <div className="space-y-8">


### PR DESCRIPTION
### Motivation
- Reduce visual noise from multiple skeletons per admin page and centralize loading UX to scoped indicators per data-driven section.
- Ensure static chrome (headers, titles, actions) renders immediately and is never blocked by data fetches.
- Show a single inline loader inside table bodies when initial table fetch returns no rows, instead of full-page or many skeleton rows.
- Preserve all existing data fetching, query params and mutation behavior while simplifying visuals.

### Description
- Added `isLoading`, `loadingText` and `emptyText` props to `DataTable` and implemented an inline centered spinner inside the table body when rows are empty and `isLoading` is true, using the existing `Spinner` component.
- Replaced multiple `Skeleton` placeholders in admin pages with single scoped spinners and early conditional rendering at each section level in `src/routes/$username/admin/index.tsx`, `src/routes/$username/admin/analytics/index.tsx`, and `src/routes/$username/admin/balance/index.tsx`.
- Aggregated loader state where appropriate by combining `isLoading` and `isFetching` from `useQuery` to only show the initial-section spinner when there is no existing data (e.g. Orders and Products pages), and wired the Orders table to pass `isLoading` into `DataTable` so the loader appears inside the table body.
- Did not change any API calls, `useQuery` keys, params, caching, mutation logic, or feature behavior; only the presentation and where loading indicators are rendered were modified.

### Testing
- Ran `npx eslint` against the touched files (`src/components/ui/data-table.tsx`, admin route files) but linting could not complete due to a missing local dependency (`@tanstack/eslint-config`), so this step failed in the current environment.
- Ran `npm run build` to validate the app bundle but it failed because `vite` is not available in the execution environment, so the build step did not complete.
- Attempted a Playwright page capture to visually verify the change, but the dev server was not running on `127.0.0.1:3000` (`ERR_EMPTY_RESPONSE`), so a runtime screenshot could not be produced.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698cd5f440008333b273dc0736805129)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added flexible loading state management with customizable messages for improved user feedback during data operations

* **Refactor**
  * Standardized and unified loading indicators throughout the admin dashboard with a consistent spinner design, replacing multiple placeholder patterns for better visual consistency and clarity

<!-- end of auto-generated comment: release notes by coderabbit.ai -->