### PR TITLE
Refactor public profile blocks into modular renderer with block-type icons

### DIFF
--- a/src/components/dashboard/blocks/PublicProfileBlocks.tsx
+++ b/src/components/dashboard/blocks/PublicProfileBlocks.tsx
@@ -1,0 +1,173 @@
+import * as React from 'react'
+import { ArrowUpRight } from 'lucide-react'
+
+import { Button } from '@/components/ui/button'
+import { Card } from '@/components/ui/card'
+import { getBlockTypeConfigOrDefault } from '@/lib/block-type-config'
+import { getBlockSkeletonClasses } from '@/lib/block-styles'
+import { cn } from '@/lib/utils'
+
+export interface PublicProfileBlock {
+  id: string
+  title: string
+  url?: string | null
+  type?: string | null
+  content?: string | null
+}
+
+interface PublicProfileBlocksProps {
+  areBlocksReady: boolean
+  blocks: Array<PublicProfileBlock>
+  cardBase: string
+  cardBaseWithHover: string
+  radiusClass: string
+  cardStyle?: React.CSSProperties
+  onOpenBlockUrl: (block: PublicProfileBlock) => void
+  onTrackClick: (blockId: string) => void
+  renderVideoBlock: (block: PublicProfileBlock) => React.ReactNode
+  renderProductBlock: (block: PublicProfileBlock) => React.ReactNode
+}
+
+function getTelegramUrl(username?: string | null): string | null {
+  const trimmed = username?.trim() || ''
+  if (!trimmed) return null
+  return `https://t.me/${trimmed.replace(/^@+/, '')}`
+}
+
+export function PublicProfileBlocks({
+  areBlocksReady,
+  blocks,
+  cardBase,
+  cardBaseWithHover,
+  radiusClass,
+  cardStyle,
+  onOpenBlockUrl,
+  onTrackClick,
+  renderVideoBlock,
+  renderProductBlock,
+}: PublicProfileBlocksProps) {
+  if (!areBlocksReady) {
+    return blocks.map((block) => (
+      <div key={block.id} className={getBlockSkeletonClasses(block.type)} />
+    ))
+  }
+
+  return blocks.map((block) => {
+    if (block.type === 'text') {
+      return (
+        <div key={block.id} className="w-full space-y-1 py-2 text-center min-h-16">
+          <h2 className={cn('text-2xl font-bold', 'text-foreground')}>
+            {block.title}
+          </h2>
+          {block.content && (
+            <p className={cn('text-sm', 'text-foreground')}>{block.content}</p>
+          )}
+        </div>
+      )
+    }
+
+    if (block.type === 'image') {
+      return (
+        <Card
+          key={block.id}
+          className={cn('w-full overflow-hidden', cardBase, radiusClass)}
+          style={cardStyle}
+        >
+          {block.content && (
+            <div className="relative w-full overflow-hidden bg-muted aspect-4/3">
+              <img
+                loading="lazy"
+                decoding="async"
+                width={1200}
+                height={900}
+                src={block.content}
+                alt="Image block"
+                className="absolute inset-0 h-full w-full object-cover"
+              />
+            </div>
+          )}
+          {block.url && (
+            <div className="px-3 pb-3">
+              <Button className="w-full" onClick={() => onOpenBlockUrl(block)}>
+                Open link
+              </Button>
+            </div>
+          )}
+        </Card>
+      )
+    }
+
+    if (block.type === 'video') {
+      return renderVideoBlock(block)
+    }
+
+    if (block.type === 'product') {
+      return renderProductBlock(block)
+    }
+
+    if (block.type === 'telegram') {
+      const telegramUrl = getTelegramUrl(block.content)
+      if (!telegramUrl) return null
+
+      const IconComponent = getBlockTypeConfigOrDefault('telegram').icon
+
+      return (
+        <Card
+          key={block.id}
+          className={cn(
+            'group w-full cursor-pointer overflow-hidden transition-all min-h-20',
+            cardBaseWithHover,
+            radiusClass,
+          )}
+          style={cardStyle}
+          onClick={() => {
+            onTrackClick(block.id)
+            window.open(telegramUrl, '_blank', 'noopener,noreferrer')
+          }}
+        >
+          <div className="flex items-center justify-between p-4">
+            <div className="flex items-center gap-4">
+              <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-muted transition-colors group-hover:bg-muted/80">
+                <IconComponent className="h-5 w-5" />
+              </div>
+              <span className="text-sm font-semibold">{block.title || 'Telegram'}</span>
+            </div>
+            <ArrowUpRight className="h-5 w-5 text-muted-foreground transition-transform group-hover:-translate-y-0.5 group-hover:translate-x-0.5" />
+          </div>
+        </Card>
+      )
+    }
+
+    if (block.type === 'discord' && !block.url) {
+      return null
+    }
+
+    const iconType = block.type === 'discord' ? 'discord' : 'link'
+    const IconComponent = getBlockTypeConfigOrDefault(iconType).icon
+
+    return (
+      <Card
+        key={block.id}
+        className={cn(
+          'group w-full cursor-pointer overflow-hidden transition-all min-h-20',
+          cardBaseWithHover,
+          radiusClass,
+        )}
+        style={cardStyle}
+        onClick={() => onOpenBlockUrl(block)}
+      >
+        <div className="flex items-center justify-between p-4">
+          <div className="flex items-center gap-4">
+            <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-muted transition-colors group-hover:bg-muted/80">
+              <IconComponent className="h-5 w-5" />
+            </div>
+            <span className="text-sm font-semibold">
+              {block.title || (block.type === 'discord' ? 'Discord' : 'Link')}
+            </span>
+          </div>
+          <ArrowUpRight className="h-5 w-5 text-muted-foreground transition-transform group-hover:-translate-y-0.5 group-hover:translate-x-0.5" />
+        </div>
+      </Card>
+    )
+  })
+}


### PR DESCRIPTION
### Motivation
- Reduce complexity in the profile route by extracting block rendering into a reusable component under `@/components/dashboard/blocks` so the route is easier to read and maintain. 
- Ensure the displayed block icons come from the centralized block configuration so UI matches `src/lib/block-type-config.ts` instead of using hard-coded icons. 
- Keep existing video/product behavior unchanged by making those render paths pluggable to avoid regressions.

### Description
- Added `src/components/dashboard/blocks/PublicProfileBlocks.tsx` which encapsulates rendering for public profile blocks (text, image, video, product, link/discord/telegram). 
- Replaced the large conditional block rendering in `src/routes/$username/index.tsx` with a single `<PublicProfileBlocks />` usage and passed `renderVideoBlock` and `renderProductBlock` render-props to preserve existing `DeferredVideoEmbed` and `ProductCard` behavior. 
- Switched social/link card icons to use `getBlockTypeConfigOrDefault(...).icon` from `src/lib/block-type-config.ts` so icons match configured block types (Telegram/Discord/Link fallbacks). 
- Removed duplicated helpers from the route (telegram URL builder and skeleton mapping) and moved that logic into the new component, plus updated imports and types (`PublicBlock` now uses the exported `PublicProfileBlock` type).

### Testing
- Ran lint on the modified files with `npm run -s lint -- src/routes/'$username'/index.tsx src/components/dashboard/blocks/PublicProfileBlocks.tsx` and resolved ordering/type-import issues so lint passed. 
- Built a production bundle with `npm run -s build` and the build completed successfully. 
- Executed `npm run -s test`, which exited with no test files found (expected for this repo). 
- Performed a local dev preview and captured a screenshot of the updated profile rendering via Playwright to visually validate the change (artifact: `artifacts/profile-blocks-refactor.png`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6999162587f883339ee1c04b363ff05b)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced public profile block rendering with improved support for text, images, videos, products, and social links including Telegram and Discord.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->